### PR TITLE
metrics aggregator is crashing when Numerical values cannot be parsed…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@
 #Build beam application and embedd in Spark container
 FROM maven:3.6.1-jdk-8-alpine AS rule-engine-builder
 
+
 RUN apk update && apk add build-base
 
 # Add and build rule engine
@@ -40,6 +41,7 @@ ADD component-splitter/checkstyle/checkstyle.xml /app/component-splitter/checkst
 RUN cd component-splitter && mvn clean package -Pflink-runner -DskipTests
 
 FROM httpd:2.4
+ENV METRICS_AGGREGATOR_VERSION=0.1.1
 COPY --from=rule-engine-builder /app/oisp-beam-rule-engine/target/rule-engine-bundled-0.1.jar /usr/local/apache2/htdocs/rule-engine-bundled-0.1.jar
-COPY --from=rule-engine-builder /app/metrics-aggregator/target/metrics-aggregator-bundled-0.1.jar /usr/local/apache2/htdocs/metrics-aggregator-bundled-0.1.jar
+COPY --from=rule-engine-builder /app/metrics-aggregator/target/metrics-aggregator-bundled-$METRICS_AGGREGATOR_VERSION.jar /usr/local/apache2/htdocs/metrics-aggregator-bundled-$METRICS_AGGREGATOR_VERSION.jar
 COPY --from=rule-engine-builder /app/component-splitter/target/component-splitter-bundled-0.1.jar /usr/local/apache2/htdocs/component-splitter-bundled-0.1.jar

--- a/metrics-aggregator/pom.xml
+++ b/metrics-aggregator/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.oisp.services</groupId>
   <artifactId>metrics-aggregator</artifactId>
-  <version>0.1</version>
+  <version>0.1.1</version>
 
   <packaging>jar</packaging>
 

--- a/metrics-aggregator/src/main/java/org/oisp/services/transforms/AggregateAll.java
+++ b/metrics-aggregator/src/main/java/org/oisp/services/transforms/AggregateAll.java
@@ -23,9 +23,13 @@ import org.apache.beam.sdk.values.KV;
 import org.oisp.services.collections.AggregatedObservation;
 import org.oisp.services.collections.Observation;
 import org.oisp.services.dataStructures.Aggregator;
+import org.oisp.services.utils.LogHelper;
+import org.slf4j.Logger;
 
 public class AggregateAll extends DoFn<KV<String, Iterable<Observation>>, AggregatedObservation> {
     private Aggregator aggregator;
+
+    private static final Logger LOG = LogHelper.getLogger(AggregateAll.class);
 
     public AggregateAll(Aggregator aggregator) {
         this.aggregator = aggregator;
@@ -48,7 +52,12 @@ public class AggregateAll extends DoFn<KV<String, Iterable<Observation>>, Aggreg
             Double max = -Double.MAX_VALUE;
             Double accum = 0.0;
             for (Observation obs : itObs) {
-                Double value = Double.parseDouble(obs.getValue());
+                Double value = 0.0;
+                try {
+                    value = Double.parseDouble(obs.getValue());
+                } catch (NumberFormatException error) {
+                    LOG.warn("Error: {}, cid: {} and value {} could not be parsed! ", error.getMessage(), firstObs.getCid(), obs.getValue());
+                }
                 accum += value;
                 if (value < min) {
                     min = value;


### PR DESCRIPTION
…. To make it more robust, it will now assume 0.0 for values which throw exceptions while parsing

Signed-off-by: Marcel Wagner <wagmarcel@web.de>