### PR TITLE
Services-operator: Another minor linter fix.

### DIFF
--- a/services-operator/beamsqlstatementsetoperator.py
+++ b/services-operator/beamsqlstatementsetoperator.py
@@ -209,7 +209,7 @@ def refresh_state(body, patch, logger):
     job_info = None
     try:
         job_info = flink_util.get_job_status(logger, job_id)
-    except requests.HTTPError as exc:
+    except requests.HTTPError:
         pass
     except requests.exceptions.RequestException as exc:
         patch.status[STATE] = States.UNKNOWN.name


### PR DESCRIPTION
Otherwise the linter complains that `exc` is unused.

We should probably add a comment while this exception can be ignored though, it is not obvious to me.

Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>