### PR TITLE
Add updating of beamsqlstatementsets CR with and without savepoints

### DIFF
--- a/services-operator/beamsqlstatementsetoperator.py
+++ b/services-operator/beamsqlstatementsetoperator.py
@@ -1,6 +1,7 @@
 """A kopf operator that manages SQL jobs on flink."""
 
 import time
+import datetime
 import os
 from enum import Enum
 
@@ -18,9 +19,13 @@ FLINK_URL = os.getenv("OISP_FLINK_REST",
 default_gateway_url = f"http://flink-sql-gateway.{oisp_namespace}:9000"
 FLINK_SQL_GATEWAY = os.getenv("OISP_FLINK_SQL_GATEWAY",
                               default=default_gateway_url)
+DEFAULT_SAVEPOINT_DIR = "/flink-savepoints"
+FLINK_SAVEPOINT_DIR = os.getenv("OISP_FLINK_SAVEPOINT_DIR",
+                                default=DEFAULT_SAVEPOINT_DIR)
+
 timer_interval_seconds = int(os.getenv("TIMER_INTERVAL", default="10"))
 timer_backoff_seconds = int(os.getenv("TIMER_BACKOFF_INTERVAL", default="10"))
-timer_backoff_temporary_failure_seconds = int(
+timer_backoff_temp_failure_seconds = int(
     os.getenv("TIMER_BACKOFF_TEMPORARY_FAILURE_INTERVAL", default="30"))
 
 
@@ -33,7 +38,19 @@ class States(Enum):
     FAILED = "FAILED"
     CANCELED = "CANCELED"
     CANCELING = "CANCELING"
+    UPDATING = "UPDATING"
+    SAVEPOINTING = "SAVEPOINTING"
+    FINISHED = "FINISHED"
     UNKNOWN = "UNKNOWN"
+    NOT_FOUND = "NOT_FOUND"
+
+
+class SavepointStates(Enum):
+    """Savepoint states as defined by Flink"""
+    SUCCESSFUL = "SUCCESSFUL"
+    IN_PROGRESS = "IN_PROGRESS"
+    NOT_FOUND = "NOT_FOUND"
+    FAILED = "FAILED"
 
 
 class DeploymentFailedException(Exception):
@@ -42,6 +59,13 @@ class DeploymentFailedException(Exception):
 
 JOB_ID = "job_id"
 STATE = "state"
+SAVEPOINT_ID = "savepoint_id"
+SAVEPOINT_LOCATION = "location"
+SAVEPOINT_STATUS = "status"
+MESSAGES = "messages"
+UPDATE_STRATEGY = "updateStrategy"
+UPDATE_STRATEGY_SAVEPOINT = "savepoint"
+UPDATE_STRATEGY_NONE = "none"
 
 
 @kopf.on.create("oisp.org", "v1alpha2", "beamsqlstatementsets")
@@ -119,12 +143,100 @@ def beamsqlviews(name: str, namespace: str, body: kopf.Body, **_):
     return {(namespace, name): body}
 
 
+@kopf.on.update("oisp.org", "v1alpha2", "beamsqlstatementsets")
+# pylint: disable=unused-argument
+# Kopf decorated functions match their expectations
+def update(body, spec, patch, logger, retries=20, **kwargs):
+    """
+    Updates a statementset
+    - Checks whether updateStrategy is defined
+        - If update strategy is defined transit to SAVEPOINTING
+        - ELSE move direclty to UPDATING
+    """
+    logger.info("update triggered")
+    state = body['status'].get(STATE)
+    job_id = body['status'].get(JOB_ID)
+    namespace = body['metadata'].get("namespace")
+    metadata_name = body['metadata'].get("name")
+    update_strategy = spec.get(UPDATE_STRATEGY)
+    logger.debug(f"update strategy is {update_strategy}")
+    if update_strategy is None or update_strategy == UPDATE_STRATEGY_NONE:
+        # No update strategy. Cancel the current job and deploy it new
+        try:
+            cancel_job_and_get_state(logger, body, patch)
+        except requests.exceptions.RequestException as exc:
+            logger.error("Could not cancel job in update process."
+                         "Try again later"
+                         f"{namespace}/{metadata_name}."
+                         f"{exc}")
+            raise kopf.TemporaryError("Could not cancel job in update process."
+                                      " Try again later"
+                                      f"{namespace}/{metadata_name}."
+                                      f"{exc}",
+                                      timer_backoff_temp_failure_seconds)\
+                from exc
+        patch.status[STATE] = States.UPDATING.name
+        patch.status[SAVEPOINT_ID] = None
+        patch.status[SAVEPOINT_LOCATION] = None
+    elif update_strategy == UPDATE_STRATEGY_SAVEPOINT:
+        try:
+            savepoint_id = body['status'].get(SAVEPOINT_ID)
+        except KeyError:
+            savepoint_id = None
+        if state == States.RUNNING.name:
+            try:
+                savepoint_id = flink_util.stop_job(logger, job_id, None)
+            except requests.exceptions.RequestException as exc:
+                logger.error("Could not stop and savepoint job in "
+                             f"{namespace}/{metadata_name}."
+                             f"{exc}")
+                raise kopf.TemporaryError("Could not stop and savepoint job in"
+                                          f" {namespace}/{metadata_name}."
+                                          f"{exc}",
+                                          timer_backoff_temp_failure_seconds)\
+                    from exc
+            patch.status[STATE] = States.SAVEPOINTING.name
+            patch.status[SAVEPOINT_ID] = savepoint_id
+        # wait for savepoint to complete
+        if savepoint_id is not None:
+            job_id = body['status'].get(JOB_ID)
+            savepoint_state = flink_util.get_savepoint_state(
+                logger, job_id, savepoint_id)
+            logger.debug(f"savepoint state {savepoint_state}")
+            if savepoint_state.get(SAVEPOINT_STATUS) in [
+              SavepointStates.FAILED.name, SavepointStates.NOT_FOUND.name]:
+                # Savepointing not possible
+                add_message(logger, body, patch,
+                            "Savepointing failed! "
+                            "Check Service configuration.",
+                            "update failure")
+                patch.status[STATE] = States.RUNNING.name
+                patch.status[SAVEPOINT_ID] = None
+                patch.status[SAVEPOINT_LOCATION] = None
+            elif savepoint_state.get(SAVEPOINT_STATUS) in [
+              SavepointStates.IN_PROGRESS.name]:
+                logger.debug("Savepointing still in progress"
+                             "try come back later")
+                raise kopf.TemporaryError("Savepointing still in progress"
+                                          " try come back later",
+                                          timer_backoff_temp_failure_seconds)
+            else:
+                # savepoint is Completed successfully, now do the updating
+                add_message(logger, body, patch,
+                            "Savepointing completed! Now updating.",
+                            "messsage")
+                logger.debug("Savepoint Completed. Now go to updating state.")
+                patch.status[SAVEPOINT_LOCATION] = \
+                    savepoint_state.get(SAVEPOINT_LOCATION)
+                patch.status[STATE] = States.UPDATING.name
+
+
 @kopf.timer("oisp.org", "v1alpha2", "beamsqlstatementsets",
             interval=timer_interval_seconds, backoff=timer_backoff_seconds)
 # pylint: disable=too-many-arguments unused-argument redefined-outer-name
 # pylint: disable=too-many-locals
 # Kopf decorated functions match their expectations
-def updates(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
+def monitor(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
             body, spec, status, **kwargs):
     """
     Managaging the main lifecycle of the beamsqlstatementset crd
@@ -142,6 +254,9 @@ def updates(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
         - CANCELED - resource has been canceled
         - CANCELING - resource is in cancelling process
         - UNKNOWN - resource cannot be monitored
+        - SAVEPOINTING - resource is currently trying to create a savepoint
+        - UPDATING - resource is currently updating, i.e. removing old jobid
+            and creating new one
 
     Transitions:
         - undefined/INITIALIZED => DEPLOYING
@@ -160,12 +275,8 @@ def updates(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
         create(body, spec, patch, logger, **kwargs)
         return
 
-    if state == States.UNKNOWN.name:
-        create(body, spec, patch, logger, **kwargs)
-        return
-
     logger.debug(
-        f"Triggered updates for {namespace}/{metadata_name}"
+        f"Triggered monitor for {namespace}/{metadata_name}"
         f" with state {state}")
     name = spec.get('name')
     if not name:
@@ -174,14 +285,14 @@ def updates(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
         name = metadata_name
     if state in [States.INITIALIZED.name, States.DEPLOYMENT_FAILURE.name]:
         # deploying
-        logger.debug(f"Deyploying {namespace}/{name}")
+        logger.debug(f"Deploying {namespace}/{name}")
 
         # create the full statement in the folloing order:
         # (1) SET statements (sqlsettings)
         # (2) Tables
         # (3) Views
 
-        ddls = create_sets(spec, namespace, name, logger)
+        ddls = create_sets(spec, body, namespace, name, logger)
 
         # get first all table ddls
         # get inputTable and outputTable
@@ -205,7 +316,7 @@ def updates(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
                                       f"{namespace}/{name}. Check the view"
                                       "definitions and table references: "
                                       f"{exc}",
-                                      timer_backoff_temporary_failure_seconds)\
+                                      timer_backoff_temp_failure_seconds)\
                 from exc
 
         # now create statement set
@@ -227,13 +338,27 @@ def updates(beamsqltables: kopf.Index, beamsqlviews: kopf.Index, patch, logger,
             logger.error(f"Could not deploy statementset {err}")
             raise kopf.TemporaryError(
                 f"Could not deploy statement: {err}",
-                timer_backoff_temporary_failure_seconds)
+                timer_backoff_temp_failure_seconds)
+
+    # If state is UPDATING - monitor the job status
+    # and if it is CANCELED => create new one
+    if state == States.UPDATING.name:
+        logger.debug("Processing updating state")
+        job_state = get_job_state(logger, body)
+        if job_state in [States.CANCELED.name, States.FINISHED.name]:
+            add_message(logger, body, patch,
+                        "Updating successful: Cancelled/Finished"
+                        " old job and creating new one",
+                        "message")
+            create(body, spec, patch, logger, **kwargs)
 
     # If state is not INITIALIZED, DEPLOYMENT_FAILURE nor CANCELED,
     # the state is monitored
-    if state not in [States.CANCELED.name, States.CANCELING.name]:
+    if state not in [States.CANCELED.name,
+       States.CANCELING.name, States.SAVEPOINTING.name, States.UPDATING.name]:
         refresh_state(body, patch, logger)
-        if patch.status[STATE] == States.UNKNOWN.name:
+        if patch.status[STATE] == States.NOT_FOUND.name:
+            logger.info("Job seems to be lost. Will re-initialize")
             patch.status[STATE] = States.INITIALIZED.name
             patch.status[JOB_ID] = None
 
@@ -258,12 +383,12 @@ def create_tables(beamsqltables, spec, body, namespace, name, logger):
                                   f"{exc}"
                                   f"{namespace}/{name}. Check the table"
                                   "definitions and references: "f"{exc}",
-                                  timer_backoff_temporary_failure_seconds)\
+                                  timer_backoff_temp_failure_seconds)\
             from exc
     return ddls
 
 
-def create_sets(spec, namespace, name, logger):
+def create_sets(spec, body, namespace, name, logger):
     """
     create the list of SET statements which configures the
     statementsets
@@ -271,7 +396,8 @@ def create_sets(spec, namespace, name, logger):
     sets = ""
     sqlsettings = spec.get('sqlsettings')
     if not sqlsettings:
-        message = f"sqlstatements not found in {namespace}/{name}"
+        message = "pipeline name not determined in"\
+                  f" {namespace}/{name}, using default"
         logger.debug(message)
         sets = f"SET pipeline.name = '{namespace}/{name}';\n"
     elif all(x for x in sqlsettings if x.get('pipeline.name') is None):
@@ -280,6 +406,15 @@ def create_sets(spec, namespace, name, logger):
             key = list(setting.keys())[0]
             value = setting.get(key)
             sets += f"SET '{key}' = '{value}';\n"
+    # add savepoint if location is set
+    try:
+        savepoint_location = body['status'].get(SAVEPOINT_LOCATION)
+        if savepoint_location is not None:
+            sets += f"SET execution.savepoint.path = '{savepoint_location}';\n"
+        logger.debug(f"Savepoint location {savepoint_location} used for sets.")
+    except KeyError:
+        pass
+
     return sets
 
 
@@ -289,13 +424,15 @@ def refresh_state(body, patch, logger):
     job_info = None
     try:
         job_info = flink_util.get_job_status(logger, job_id)
-    except requests.HTTPError:
-        pass
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 404:
+            patch.status[STATE] = States.NOT_FOUND.name
+            return
     except requests.exceptions.RequestException as exc:
         patch.status[STATE] = States.UNKNOWN.name
         raise kopf.TemporaryError(
             f"Could not monitor task {job_id}: {exc}",
-            timer_backoff_temporary_failure_seconds) from exc
+            timer_backoff_temp_failure_seconds) from exc
     if job_info is not None:
         patch.status[STATE] = job_info.get("state")
     else:
@@ -340,3 +477,39 @@ def deploy_statementset(statementset, logger):
     logger.debug(f"Response: {response.json()}")
     job_id = response.json().get("jobid")
     return job_id
+
+
+def cancel_job_and_get_state(logger, body, patch):
+    """
+    Cancel job if it is running
+    and return the Job state
+    """
+    job_id = body['status'].get(JOB_ID)
+    job_info = flink_util.get_job_status(logger, job_id)
+    job_state = job_info.get("state")
+    if job_state == States.RUNNING.name:
+        flink_util.cancel_job(logger, job_id)
+    return job_state
+
+
+def get_job_state(logger, body):
+    """
+    Get job state
+    """
+    job_id = body['status'].get(JOB_ID)
+    job_info = flink_util.get_job_status(logger, job_id)
+    job_state = job_info.get("state")
+    logger.debug(f"job state is {job_state}")
+    return job_state
+
+
+def add_message(logger, body, patch, reason, mtype):
+    """
+    add message to status oject of CR
+    """
+    messages = body.status.get(MESSAGES)
+    if messages is None:
+        messages = []
+    messages.append({"timestamp": f"{datetime.datetime.now()}",
+                    "type": mtype, "message": reason})
+    patch.status[MESSAGES] = messages

--- a/services-operator/flink_util.py
+++ b/services-operator/flink_util.py
@@ -19,7 +19,6 @@ def get_job_status(logger, job_id):
         f"{FLINK_URL}/jobs/{job_id}")
     job_response.raise_for_status()
     job_response = job_response.json()
-    logger.debug(f"Received job status: {job_response}")
     return job_response
 
 
@@ -30,3 +29,62 @@ def cancel_job(logger, job_id):
     response = requests.patch(f"{FLINK_URL}/jobs/{job_id}")
     if response.status_code != 202:
         raise CancelJobFailedException("Could not cancel job {job_id}")
+
+
+def stop_job(logger, job_id, savepoint_dir):
+    """Stop a job and use savepoint
+       Returns triggerid
+    """
+    logger.debug(f"Stop job {job_id} and request savepoint {savepoint_dir}")
+    json = {}
+    if savepoint_dir is not None:
+        json = {"targetDirectory": f"{savepoint_dir}"}
+    logger.info(f"sending object: {json}")
+    job_response = requests.post(
+        f"{FLINK_URL}/jobs/{job_id}/stop", json=json)
+    job_response.raise_for_status()
+    if job_response.status_code != 202:
+        raise CancelJobFailedException("Could not trigger stop of job "
+                                       "{job_id}")
+    job_response = job_response.json()
+    logger.debug(f"Received job status: {job_response}")
+    return job_response['request-id']
+
+
+def get_savepoint_state(logger, job_id, savepoint_id):
+    """Retrieves the state of the Savepoint trigger
+       Returns a dictionary {"status": status, "location" location}
+       Savepoint status:
+       - IN_PROGRESS
+       - SUCCESSFUL
+       - NOT_FOUND
+       - FAILED
+    """
+    logger.debug(f"Check state of savepoint trigger {savepoint_id}"
+                 " for job  {job_id} ")
+    response = requests.get(
+        f"{FLINK_URL}/jobs/{job_id}/savepoints/{savepoint_id}")
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        if response.status_code == 404:
+            logger.debug(f"Trigger {savepoint_id} not found")
+            return {"status": "NOT_FOUND", "location": None}
+    response.raise_for_status()
+    if response.status_code != 200:
+        raise CancelJobFailedException("Could not get status of savepoint"
+                                       " trigger {savepoint_id} for job"
+                                       " {job_id}")
+    response = response.json()
+    logger.info(f"Received job status: {response['status']}")
+    status = response['status'].get('id')
+    if status == "IN_PROGRESS":
+        return {"status": status}
+    try:
+        if response['operation'] is None or \
+          response['operation'].get('failure-cause') is not None:
+            return {"status": "FAILED", "location": None}
+    except KeyError:
+        pass
+    return {"status": response['status'].get('id'),
+            "location": response['operation'].get('location')}

--- a/services-operator/kubernetes/crd.yml
+++ b/services-operator/kubernetes/crd.yml
@@ -111,6 +111,12 @@ spec:
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                updateStrategy:
+                  type: string
+                  enum: [
+                    "none",
+                    "savepoint"
+                  ]
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/services-operator/test/test_beamsqlstatementsetoperator.py
+++ b/services-operator/test/test_beamsqlstatementsetoperator.py
@@ -49,7 +49,7 @@ class TestInit(TestCase):
         self.assertIsNone(patch.status['job_id'])
 
 
-class TestUpdates(TestCase):
+class TestMonitoring(TestCase):
     def create_ddl_from_beamsqltables(beamsqltable, logger):
         return "DDL;"
 
@@ -63,8 +63,8 @@ class TestUpdates(TestCase):
     def submit_statementset_failed(statementset, logger):
         raise target.DeploymentFailedException("Mock submission failed")
 
-    def update_status_unknown(body, patch, logger):
-        patch.status["state"] = "UNKNOWN"
+    def update_status_not_found(body, patch, logger):
+        patch.status["state"] = "NOT_FOUND"
 
     @patch('beamsqlstatementsetoperator.tables_and_views.create_ddl_from_beamsqltables',
            create_ddl_from_beamsqltables)
@@ -90,7 +90,7 @@ class TestUpdates(TestCase):
         patch.status = {}
 
         beamsqltables = {("namespace", "table"): ({}, {})}
-        target.updates(beamsqltables, None, patch,  Logger(),
+        target.monitor(beamsqltables, None, patch,  Logger(),
                        body, body["spec"], body["status"])
         self.assertEqual(patch.status['state'], "DEPLOYING")
         self.assertEqual(patch.status['job_id'], "job_id")
@@ -120,7 +120,7 @@ class TestUpdates(TestCase):
 
         beamsqltables = {("namespace", "table"): ({}, {})}
         try:
-            target.updates(beamsqltables, None, patch,  Logger(),
+            target.monitor(beamsqltables, None, patch,  Logger(),
                            body, body["spec"], body["status"])
         except kopf.TemporaryError:
             pass
@@ -152,7 +152,7 @@ class TestUpdates(TestCase):
 
         beamsqltables = {}
         with self.assertRaises(kopf.TemporaryError) as cm:
-            target.updates(beamsqltables, None, patch, Logger(),
+            target.monitor(beamsqltables, None, patch, Logger(),
                            body, body["spec"], body["status"])
             self.assertTrue(str(cm.exception).startswith(
                 "Table DDLs could not be created for namespace/name."))
@@ -161,7 +161,7 @@ class TestUpdates(TestCase):
            create_ddl_from_beamsqltables)
     @patch('beamsqlstatementsetoperator.deploy_statementset',
            submit_statementset_failed)
-    @patch('beamsqlstatementsetoperator.refresh_state', update_status_unknown)
+    @patch('beamsqlstatementsetoperator.refresh_state', update_status_not_found)
     def test_update_handle_unknown(self):
         body = {
             "metadata": {
@@ -183,7 +183,7 @@ class TestUpdates(TestCase):
 
         beamsqltables = {}
 
-        target.updates(beamsqltables, None, patch, Logger(),
+        target.monitor(beamsqltables, None, patch, Logger(),
                        body, body["spec"], body["status"])
         self.assertEqual(patch.status["state"], "INITIALIZED")
         self.assertIsNone(patch.status["job_id"])
@@ -200,7 +200,7 @@ class TestDeletion(TestCase):
         pass
 
     def cancel_job_error(logger, job_id):
-        raise Exception("Could not cancel job")
+        raise kopf.TemporaryError("Could not cancel job")
 
     @patch('kopf.info', kopf_info)
     def test_canceled_delete(self):
@@ -321,6 +321,209 @@ class TestDeletion(TestCase):
             self.assertTrue(str(cm.exception).startswith("Error trying"))
         self.assertNotEqual(patch.status["state"], "CANCELING")
 
+job_canceled = False
+
+class TestUpdate(TestCase):
+    def cancel_job(logger, job_id):
+        global job_canceled
+        job_canceled = True
+        pass
+    def get_job_status(logger, job_id):
+        return {
+            "state": "RUNNING"
+        }
+    
+    def get_job_status_not_running(logger, job_id):
+        return {
+            "state": "UNKNOWN"
+        }
+
+    def cancel_job_and_get_state(logger, body, patch):
+        pass
+
+    
+    def stop_job(logger, job_id, savepoint_dir):
+        return "savepoint_id"
+
+
+    def get_savepoint_state_successful(logger, job_id, savepoint_id):
+        return {
+            "status": "SUCCESSFUL",
+            "location": "location"
+        }
+
+
+    def get_savepoint_state_in_progress(logger, job_id, savepoint_id):
+        return {
+            "status": "IN_PROGRESS",
+            "location": "location"
+        }
+
+
+    def get_savepoint_state_not_found(logger, job_id, savepoint_id):
+        return {
+            "status": "NOT_FOUND",
+            "location": "location"
+        }
+
+    def add_message(logger, body, patch, reason, mtype):
+        pass
+
+    @patch('kopf.info', kopf_info)
+    @patch('flink_util.cancel_job', cancel_job)
+    @patch('flink_util.get_job_status', get_job_status)
+    def test_cancel_job_and_get_state_running(self):
+        global job_canceled
+        body = {           
+            "status": {
+                "job_id": "job_id"
+            } 
+        }
+        job_canceled = False
+        job_state = target.cancel_job_and_get_state(Logger(), body, None)
+        self.assertEqual("RUNNING", job_state)
+        self.assertEqual(True, job_canceled)
+
+
+    @patch('kopf.info', kopf_info)
+    @patch('flink_util.cancel_job', cancel_job)
+    @patch('flink_util.get_job_status', get_job_status_not_running)
+    def test_cancel_job_and_get_state_running(self):
+        global job_canceled
+        body = {           
+            "status": {
+                "job_id": "job_id"
+            } 
+        }
+        job_canceled = False
+        job_state = target.cancel_job_and_get_state(Logger(), body, None)
+        self.assertEqual("UNKNOWN", job_state)
+        self.assertEqual(False, job_canceled)
+
+
+    @patch('kopf.info', kopf_info)
+    @patch('beamsqlstatementsetoperator.cancel_job_and_get_state', cancel_job_and_get_state)
+    def test_update_no_savepoint(self):
+        body = {
+            "metadata": {
+                "name": "name",
+                "namespace": "namespace"
+            },
+            "spec": {
+            },
+            "status": {
+                "job_id": "job_id",
+                "state": "RUNNING",
+            } 
+        }
+        patch = Bunch()
+        patch.status = {}
+        target.update(body, body["spec"], patch, Logger())
+        self.assertEqual(patch.status["state"], "UPDATING")
+        self.assertIsNone(patch.status["savepoint_id"])
+        self.assertIsNone(patch.status["location"])
+
+
+    @patch('kopf.info', kopf_info)
+    @patch('beamsqlstatementsetoperator.cancel_job_and_get_state', cancel_job_and_get_state)
+    def test_update_none_savepoint(self):
+        body = {
+            "metadata": {
+                "name": "name",
+                "namespace": "namespace"
+            },
+            "spec": {
+                "updateStrategy": None
+            },
+            "status": {
+                "job_id": "job_id",
+                "state": "RUNNING",
+            } 
+        }
+        patch = Bunch()
+        patch.status = {}
+        target.update(body, body["spec"], patch, Logger())
+        self.assertEqual(patch.status["state"], "UPDATING")
+        self.assertIsNone(patch.status["savepoint_id"])
+        self.assertIsNone(patch.status["location"])
+
+
+    @patch('kopf.info', kopf_info)
+    @patch('flink_util.stop_job', stop_job)
+    @patch('flink_util.get_savepoint_state', get_savepoint_state_successful)
+    @patch('beamsqlstatementsetoperator.add_message', add_message)
+    def test_update_savepoint_successful(self):
+        body = {
+            "metadata": {
+                "name": "name",
+                "namespace": "namespace"
+            },
+            "spec": {
+                "updateStrategy": "savepoint"
+            },
+            "status": {
+                "job_id": "job_id",
+                "state": "RUNNING",
+            } 
+        }
+        patch = Bunch()
+        patch.status = {}
+        target.update(body, body["spec"], patch, Logger())
+        self.assertEqual(patch.status["savepoint_id"], "savepoint_id")
+        self.assertEqual(patch.status["state"], "UPDATING")
+        self.assertEqual(patch.status["location"], "location")
+
+
+    @patch('kopf.info', kopf_info)
+    @patch('flink_util.stop_job', stop_job)
+    @patch('flink_util.get_savepoint_state', get_savepoint_state_in_progress)
+    @patch('beamsqlstatementsetoperator.add_message', add_message)
+    def test_update_savepoint_in_progress(self):
+        body = {
+            "metadata": {
+                "name": "name",
+                "namespace": "namespace"
+            },
+            "spec": {
+                "updateStrategy": "savepoint"
+            },
+            "status": {
+                "job_id": "job_id",
+                "state": "RUNNING",
+            } 
+        }
+        patch = Bunch()
+        patch.status = {}
+        with self.assertRaises(kopf.TemporaryError) as cm:
+            target.update(body, body["spec"], patch, Logger())
+        self.assertEqual(patch.status["savepoint_id"], "savepoint_id")
+        self.assertEqual(patch.status["state"], "SAVEPOINTING")
+
+
+    @patch('kopf.info', kopf_info)
+    @patch('flink_util.stop_job', stop_job)
+    @patch('flink_util.get_savepoint_state', get_savepoint_state_not_found)
+    @patch('beamsqlstatementsetoperator.add_message', add_message)
+    def test_update_savepoint_not_found(self):
+        body = {
+            "metadata": {
+                "name": "name",
+                "namespace": "namespace"
+            },
+            "spec": {
+                "updateStrategy": "savepoint"
+            },
+            "status": {
+                "job_id": "job_id",
+                "state": "RUNNING",
+            } 
+        }
+        patch = Bunch()
+        patch.status = {}
+        target.update(body, body["spec"], patch, Logger())
+        self.assertIsNone(patch.status["savepoint_id"])
+        self.assertEqual(patch.status["state"], "RUNNING")
+        self.assertIsNone(patch.status["location"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Update of bsqls CR is processed by operator
- If updateStrategy is selected to be None, update just cancels the old job and redeploys
- If updateStrategy is "savepoint" it will first trigger a savepoint, then cancel and
  restart with savepoint
- Unit tests for update added
- In general, operator is triggering no longer when connection to flink jobmanager
  is lost
- Redeployment is only triggerd from the NOT_FOUND state

See #35
Closes #35

Signed-off-by: Marcel <wagmarcel@web.de>